### PR TITLE
Add to_coo / from_coo

### DIFF
--- a/sp_map.pyx.in
+++ b/sp_map.pyx.in
@@ -45,6 +45,9 @@ cdef extern from "sp_map.h" namespace "sparray":
         void todense(const map_array_t[T] *src,
                      void* dest,
                      const single_index_type num_elem) except +
+        void to_coo(const map_array_t[T] *src,
+                    void *data, void *row, void *clmn,
+                    const single_index_type num_elem) except +
 
         # $x <- alpha f(x) + beta x$
         # default is alpha=1 and beta=0
@@ -286,6 +289,39 @@ cdef class MapArray:
         for idx, val in np.ndenumerate(arr):
             self[idx] = val
         return self
+
+    def to_coo(self):
+        """Return COO style arrays for data, rows and columns.
+
+        Returns
+        -------
+        data : ndarray
+            Non-zero values.
+        (row, col) : tuple of ndarrays
+            Indices of nonzero elements, such that 
+            ``self[row[k], col[k]] = data[k]``.
+
+        Notes
+        -----
+        This function ignores the `fill_value`.
+
+        """
+        cdef npy_intp[1] sh
+        cdef cnp.ndarray row, clmn, data
+
+        {{for NUM, CT in zip(TNUMS, CTYPES)}}
+        if self.typenum == {{NUM}}:
+            sh[0] = <npy_intp>self.p.{{CT}}_ptr.count_nonzero()
+            row = PyArray_SimpleNew(1, sh, cnp.NPY_INTP)   # XXX: int32 indices?
+            clmn = PyArray_SimpleNew(1, sh, cnp.NPY_INTP)
+            data = PyArray_SimpleNew(1, sh, {{NUM}})
+            op_{{CT}}.to_coo(self.p.{{CT}}_ptr,
+                             PyArray_DATA(data),
+                             PyArray_DATA(row),
+                             PyArray_DATA(clmn),
+                             PyArray_SIZE(data))
+            return data, (row, clmn)
+        {{endfor}}
 
     ##### Single element access #####
 

--- a/sp_map.pyx.in
+++ b/sp_map.pyx.in
@@ -323,6 +323,28 @@ cdef class MapArray:
             return data, (row, clmn)
         {{endfor}}
 
+    @classmethod
+    def from_coo(cls, data, row_col):
+        """Construct from a COO style triplet of arrays.
+
+        Given three 1D arrays, `data`, `row` and `col`, return a MapArray
+        instance ``m`` such that ``m[row[k], col[k]] = data[k]`` for
+        ``k in range(n)``.
+
+        Parameters
+        ----------
+        data : array_like, shape (n, )
+            Nonzero values.
+        (row, col) :  tuple of array_likes, both shape (n,)
+            Indices of nonzero elements.
+
+        """
+        row, col = row_col
+        self = MapArray(dtype=data.dtype)
+        for val, r, c in zip(data, row, col):
+            self[r, c] = val
+        return self
+
     ##### Single element access #####
 
     def __getitem__(self, tpl):

--- a/test_basic.py
+++ b/test_basic.py
@@ -153,6 +153,15 @@ class BasicMixin(object):
         assert_equal(row, coom.row)
         assert_equal(col, coom.col)
 
+    def test_from_coo(self):
+        rndm = np.random.RandomState(122)
+        a = rndm.random_sample(size=(4, 4))
+        m = MapArray.from_dense(a)
+        data, (row, col) = m.to_coo()
+
+        m1 = MapArray.from_coo(data, (row, col))
+        assert_equal(m, m1)
+
     def test_indexing(self):
         ma = MapArray(dtype=self.dtype)
         val = self.dtype(2)

--- a/test_basic.py
+++ b/test_basic.py
@@ -13,6 +13,11 @@ except ImportError:
         return vstr
 OLD_NUMPY = NumpyVersion(np.__version__) < '1.9.1'
 
+try:
+    from scipy import sparse
+    HAVE_SCIPY = True
+except ImportError:
+    HAVE_SCIPY = False
 
 from sp_map import MapArray
 
@@ -135,6 +140,18 @@ class BasicMixin(object):
         assert_equal(row, [1])
         assert_equal(col, [j])
         assert_equal(data, self.dtype(1))
+
+    @skipif(not HAVE_SCIPY)
+    def test_coo_matrix(self):
+        rndm = np.random.RandomState(122)
+        a = rndm.random_sample(size=(8, 8))
+        coom = sparse.coo_matrix(a)
+
+        m = MapArray.from_dense(a)
+        data, (row, col) = m.to_coo()
+        assert_equal(data, coom.data)
+        assert_equal(row, coom.row)
+        assert_equal(col, coom.col)
 
     def test_indexing(self):
         ma = MapArray(dtype=self.dtype)

--- a/test_basic.py
+++ b/test_basic.py
@@ -117,6 +117,25 @@ class BasicMixin(object):
         assert_equal(m.dtype, arr.dtype)
         assert_allclose(m.todense(), arr, atol=1e-15)
 
+    def test_co_coo(self):
+        m = MapArray(dtype=self.dtype)
+        m[1, 2] = self.dtype(11)
+        m[0, 0] = self.dtype(22)
+
+        data, (row, col) = m.to_coo()
+        assert_equal(row, [0, 1])
+        assert_equal(col, [0, 2])
+        assert_equal(data, [self.dtype(22), self.dtype(11)])
+
+    def test_to_coo_int32_overflow(self):
+        ma = MapArray(dtype=self.dtype)
+        j = np.iinfo(np.int32).max + 1
+        ma[1, j] = self.dtype(1)
+        data, (row, col) = ma.to_coo()
+        assert_equal(row, [1])
+        assert_equal(col, [j])
+        assert_equal(data, self.dtype(1))
+
     def test_indexing(self):
         ma = MapArray(dtype=self.dtype)
         val = self.dtype(2)


### PR DESCRIPTION
Both methods accept/return a triplet of arrays, `data, (row, col)` which can be directly fed to `scipy.sparse.coo_matrix`. 
This way we avoid a hard dependency on scipy. 