### PR TITLE
C types

### DIFF
--- a/common_types.h
+++ b/common_types.h
@@ -1,0 +1,6 @@
+#ifndef SP_MAP_TYPES
+#define SP_MAP_TYPES
+
+typedef long int single_index_type;  // FIXME: npy_intp, likely Py_ssize_t
+
+#endif

--- a/common_types.pxd
+++ b/common_types.pxd
@@ -1,0 +1,6 @@
+#
+# This file is basically a shim with ctypedefs for common_types.h, so that
+# these can be cimported.
+#
+cdef extern from "common_types.h":
+    ctypedef long int single_index_type

--- a/fixed_cap.h
+++ b/fixed_cap.h
@@ -3,10 +3,9 @@
 #include<assert.h>
 #include<iostream>
 #include<string>
+#include"common_types.h"
 
 namespace sparray {
-
-typedef long int single_index_type;  // FIXME: npy_intp, likely Py_ssize_t
 
 
 template<typename I=single_index_type, size_t num_dim=2>
@@ -26,7 +25,8 @@ struct fixed_capacity
     fixed_capacity(const I* c_arr = NULL);  // NB: no range checking
 
 };
-// XXX: zero-initialize?
+
+typedef fixed_capacity<single_index_type, 2> index_type;
 
 
 template<typename I, size_t num_dim>

--- a/fixed_cap.h
+++ b/fixed_cap.h
@@ -54,14 +54,14 @@ struct fixed_capacity_cmp
     }
 };
 
-#define FC_ELEM(fc, j) (fc).elem_[(j)]
-#define FC_ELEMS(fc) (fc).elem_
-
-
 std::string bool_outp(const bool& x){ return x ? "true" : "false"; }
 
 
 } // namespace sparray
+
+
+#define FC_ELEM(fc, j) (fc).elem_[(j)]
+#define FC_ELEMS(fc) (fc).elem_
 
 
 template<typename I, size_t num_dim>

--- a/sp_map.pyx.in
+++ b/sp_map.pyx.in
@@ -7,17 +7,13 @@ cimport numpy as cnp
 from numpy cimport PyArray_SimpleNew, PyArray_DATA, PyArray_SIZE, npy_intp, npy_bool
 from cpython.object cimport PyObject_IsTrue, PyObject_RichCompare
 
+# Indexing type declarations
+from common_types cimport single_index_type
 
 cdef extern from "fixed_cap.h" namespace "sparray":
-    cdef cppclass fixed_capacity[I]:
-        fixed_capacity() except +
-        fixed_capacity(const I*) except +
-        I& operator[](size_t j) except +
-        long int[] elem_
-
-
-ctypedef long int single_index_type            # this needs ot be in sync w/C++
-ctypedef fixed_capacity[long int] index_type   # XXX: can't do fixed_capacity[single_index_type]
+    cdef cppclass index_type:
+        single_index_type& operator[](size_t j) except +
+        single_index_type[] elem_
 
 
 cdef extern from "sp_map.h" namespace "sparray":

--- a/sp_map.pyx.in
+++ b/sp_map.pyx.in
@@ -13,7 +13,9 @@ from common_types cimport single_index_type
 cdef extern from "fixed_cap.h" namespace "sparray":
     cdef cppclass index_type:
         single_index_type& operator[](size_t j) except +
-        single_index_type[] elem_
+
+cdef extern from "fixed_cap.h":
+    single_index_type[] FC_ELEMS(index_type) nogil
 
 
 cdef extern from "sp_map.h" namespace "sparray":
@@ -357,7 +359,7 @@ cdef class MapArray:
         if self.typenum == {{NUM}}:
             nd = <int>self.p.{{CT}}_ptr.ndim()
             a = PyArray_SimpleNew(nd,
-                                  <npy_intp*>self.p.{{CT}}_ptr.shape().elem_,
+                                  <npy_intp*>FC_ELEMS(self.p.{{CT}}_ptr.shape()),
                                   {{NUM}})
             op_{{CT}}.todense(self.p.{{CT}}_ptr, PyArray_DATA(a), PyArray_SIZE(a))
             return a


### PR DESCRIPTION
collect together single_index_type typedefs, simplify wrapping of index_type.

closes #11 