### PR TITLE
binops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,20 @@ matrix:
     - python: 3.5
       env:
         - UPGRADE="--upgrade"
+    - python: 2.7
+      env:
+        - HAVE_SCIPY=1
+    - python: 3.5
+      env:
+        - HAVE_SCIPY=1
 before_install:
     - travis_retry pip install --install-option="--no-cython-compile" Cython>=0.23.4
     - travis_retry pip install nose
     - travis_retry pip install $UPGRADE numpy
+    - |
+      if [ "${HAVE_SCIPY}" == "1" ]; then
+        travis_retry pip install scipy --timeout 60 --trusted-host travis-wheels.scikit-image.org -f http://travis-wheels.scikit-image.org/
+      fi
 script:
     - python -c'import numpy as np; print(np.__version__)'
     - python setup.py build_ext -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - UPGRADE="--upgrade"
     - python: 2.7
       env:
+        - UPGRADE="--upgrade"
         - HAVE_SCIPY=1
     - python: 3.5
       env:

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -508,12 +508,16 @@ cdef class MapArray:
         if isinstance(other, MapArray):
             return _i{{op}}_impl(self, other)
 
-        # else, other is a scalar.
-        dt = np.asarray(other).dtype     # XXX there must be a more direct way
-        arr_other = MapArray(shape=self.shape,
-                             dtype=dt,
-                             fill_value=other)
-        return _i{{op}}_impl(self, arr_other)
+        # else, other must be a scalar
+        try:
+            dt = np.asarray(other).dtype     # XXX there must be a more direct way
+            arr_other = MapArray(shape=self.shape,
+                                 dtype=dt,
+                                 fill_value=other)
+            return _i{{op}}_impl(self, arr_other)
+        except TypeError:
+            # failed to convert other to MapArray. Give up.
+            return NotImplemented
 
     def __{{op}}__(self, other):
         if isinstance(self, MapArray):
@@ -529,11 +533,15 @@ cdef class MapArray:
                 return self {{symb}} other.todense()
 
             # else, self must be a scalar
-            dt = np.asarray(self).dtype     # XXX there must be a more direct way
-            arr_self = MapArray(shape=other.shape,
-                                 dtype=dt,
-                                 fill_value=self)
-            return _i{{op}}_impl(arr_self, other)
+            try:
+                dt = np.asarray(self).dtype     # XXX there must be a more direct way
+                arr_self = MapArray(shape=other.shape,
+                                     dtype=dt,
+                                     fill_value=self)
+                return _i{{op}}_impl(arr_self, other)
+            except TypeError:
+                # conversion to MapArray failed. Give up.
+                return NotImplemented
     {{endfor}}
 
     ########### Booleans ########################

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -508,6 +508,18 @@ cdef class MapArray:
         if isinstance(other, MapArray):
             return _i{{op}}_impl(self, other)
 
+        # try checking if other quacks like a scipy.sparse matrix
+        if hasattr(other, 'tocoo'):
+            coo = other.tocoo()
+            try:
+                data, row, col = coo.data, coo.row, coo.col
+                row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
+                col = col.astype(np.intp)
+                coo_other = MapArray.from_coo(data, (row, col))
+                return _i{{op}}_impl(self, coo_other)
+            except AttributeError:
+                return NotImplemented
+
         # else, other must be a scalar
         try:
             dt = np.asarray(other).dtype     # XXX there must be a more direct way

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -157,7 +157,6 @@ cdef class MapArray:
     --------
     >>> from sp_map import MapArray as M
     >>> m = M()
-    >>> m = M()
     >>> m.shape
     (0, 0)
 
@@ -515,12 +514,12 @@ cdef class MapArray:
             coo = other.tocoo()
             try:
                 data, row, col = coo.data, coo.row, coo.col
-                row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
-                col = col.astype(np.intp)
-                coo_other = MapArray.from_coo(data, (row, col))
-                return _i{{op}}_impl(self, coo_other)
             except AttributeError:
                 return NotImplemented
+            row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
+            col = col.astype(np.intp)
+            coo_other = MapArray.from_coo(data, (row, col))
+            return _i{{op}}_impl(self, coo_other)
 
         # else, other must be a scalar
         try:
@@ -545,6 +544,18 @@ cdef class MapArray:
             # other must be a MapArray
             if isinstance(self, np.ndarray):
                 return self {{symb}} other.todense()
+
+            # try checking if self quacks like a scipy.sparse matrix
+            if hasattr(self, 'tocoo'):
+                coo = self.tocoo()
+                try:
+                    data, row, col = coo.data, coo.row, coo.col
+                except AttributeError:
+                    return NotImplemented
+                row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
+                col = col.astype(np.intp)
+                coo_self = MapArray.from_coo(data, (row, col))
+                return _i{{op}}_impl(coo_self, other)
 
             # else, self must be a scalar
             try:

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -596,6 +596,17 @@ cdef class MapArray:
         if isinstance(other, MapArray):
             return _richcmp_impl(self, other, op)
 
+        if hasattr(other, "tocoo"):
+            coo = other.tocoo()
+            try:
+                data, row, col = coo.data, coo.row, coo.col
+            except AttributeError:
+                return NotImplemented
+            row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
+            col = col.astype(np.intp)
+            coo_other = MapArray.from_coo(data, (row, col))
+            return _richcmp_impl(self, coo_other, op)            
+
         # else, other is a scalar
         dt = np.asarray(other).dtype     # XXX there must be a more direct way
         arr_other = MapArray(shape=self.shape,

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -4,7 +4,8 @@
 
 import numpy as np
 cimport numpy as cnp
-from numpy cimport PyArray_SimpleNew, PyArray_DATA, PyArray_SIZE, npy_intp, npy_bool
+from numpy cimport (PyArray_SimpleNew, PyArray_DATA, PyArray_SIZE,
+                    npy_intp, npy_bool, npy_int, npy_long, npy_longlong)
 from cpython.object cimport PyObject_IsTrue, PyObject_RichCompare
 
 # Indexing type declarations
@@ -94,8 +95,9 @@ cdef extern from "elementwise_ops.h" namespace "sparray":
 
 
 {{py:
-CTYPES_GEN = ['long', 'float', 'double']
-TNUMS_GEN = ['cnp.NPY_LONG', 'cnp.NPY_FLOAT', 'cnp.NPY_DOUBLE']
+CTYPES_GEN = ['npy_int', 'npy_long', 'npy_longlong', 'float', 'double']
+TNUMS_GEN = ['cnp.NPY_INT', 'cnp.NPY_LONG', 'cnp.NPY_LONGLONG',
+             'cnp.NPY_FLOAT', 'cnp.NPY_DOUBLE']
 CONDS_GEN = ['if'] + ['elif']*(len(TNUMS_GEN) - 1)
 
 # add types which need special casing (eg get/set)

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -547,6 +547,17 @@ cdef class MapArray:
 
             # try checking if self quacks like a scipy.sparse matrix
             if hasattr(self, 'tocoo'):
+                # csr*map is ambiguous: is it matrix multiply or elementwise?
+                # refuse the temptation to guess and give up.
+                # FIXME: this actually fails to work. The reason is that
+                # sparse matrices check dimensions *before* handing over to
+                # MapArray. Maybe the right thing to do is to bail out
+                # from both csr * map and map * csr (even though the latter works).
+                {{if op == "mul"}}
+                raise ValueError("matrix times array is ambiguous. Please "
+                                 "decide if you want matrix or elementwise "
+                                 "multiplication.")
+                {{else}}
                 coo = self.tocoo()
                 try:
                     data, row, col = coo.data, coo.row, coo.col
@@ -556,6 +567,7 @@ cdef class MapArray:
                 col = col.astype(np.intp)
                 coo_self = MapArray.from_coo(data, (row, col))
                 return _i{{op}}_impl(coo_self, other)
+                {{endif}}
 
             # else, self must be a scalar
             try:
@@ -567,6 +579,7 @@ cdef class MapArray:
             except TypeError:
                 # conversion to MapArray failed. Give up.
                 return NotImplemented
+
     {{endfor}}
 
     ########### Booleans ########################

--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -511,14 +511,9 @@ cdef class MapArray:
 
         # try checking if other quacks like a scipy.sparse matrix
         if hasattr(other, 'tocoo'):
-            coo = other.tocoo()
-            try:
-                data, row, col = coo.data, coo.row, coo.col
-            except AttributeError:
-                return NotImplemented
-            row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
-            col = col.astype(np.intp)
-            coo_other = MapArray.from_coo(data, (row, col))
+            coo_other = _try_converting_from_sparse(other)
+            if coo_other is NotImplemented:
+                return coo_other
             return _i{{op}}_impl(self, coo_other)
 
         # else, other must be a scalar
@@ -558,14 +553,9 @@ cdef class MapArray:
                                  "decide if you want matrix or elementwise "
                                  "multiplication.")
                 {{else}}
-                coo = self.tocoo()
-                try:
-                    data, row, col = coo.data, coo.row, coo.col
-                except AttributeError:
-                    return NotImplemented
-                row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
-                col = col.astype(np.intp)
-                coo_self = MapArray.from_coo(data, (row, col))
+                coo_self = _try_converting_from_sparse(self)
+                if coo_self is NotImplemented:
+                    return coo_self
                 return _i{{op}}_impl(coo_self, other)
                 {{endif}}
 
@@ -597,14 +587,9 @@ cdef class MapArray:
             return _richcmp_impl(self, other, op)
 
         if hasattr(other, "tocoo"):
-            coo = other.tocoo()
-            try:
-                data, row, col = coo.data, coo.row, coo.col
-            except AttributeError:
-                return NotImplemented
-            row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
-            col = col.astype(np.intp)
-            coo_other = MapArray.from_coo(data, (row, col))
+            coo_other = _try_converting_from_sparse(other)
+            if coo_other is NotImplemented:
+                return coo_other
             return _richcmp_impl(self, coo_other, op)            
 
         # else, other is a scalar
@@ -755,6 +740,19 @@ def _i{{op}}_impl(MapArray self not None, MapArray other not None):
     {{endfor}}
     raise NotImplementedError("_i{{op}}_: typecode %s not understood." % self.typenum)
 {{endfor}}
+
+
+def _try_converting_from_sparse(what):
+    """Convert a scipy.sparse matrix to MapArray. To be used in binops.
+    """
+    coo = what.tocoo()
+    try:
+        data, row, col = coo.data, coo.row, coo.col
+    except AttributeError:
+        return NotImplemented
+    row = row.astype(np.intp)  # XXX how MapArray.from_coo wants it
+    col = col.astype(np.intp)
+    return MapArray.from_coo(data, (row, col))
 
 
 cnp.import_array()

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -338,6 +338,28 @@ class ArithmeticsMixin(object):
         assert_allclose(ma2.todense(),
                         self.op(ma.todense(), ma.todense()), atol=1e-15)
 
+    @skipif(not HAVE_SCIPY)
+    def test_sparse_scipy_sparse_interop(self):
+        # MapArray + csr_matrix should work
+        ma1 = self.ma.copy()
+        dense = self.rhs.todense()
+        csr = sparse.csr_matrix(dense)
+
+        res = self.op(ma1, csr)
+        assert_(isinstance(res, MapArray))
+        assert_allclose(res.todense(),
+                        self.op(ma1.todense(), csr.toarray()), atol=1e-15)
+
+        # also check the in-place version
+        ma1 = self.ma.copy()
+        dense = self.rhs.todense()
+        csr = sparse.csr_matrix(dense)
+
+        ma1 = self.iop(ma1, csr)
+        assert_(isinstance(ma1, MapArray))
+        assert_allclose(res.todense(),
+                        self.op(self.ma.todense(), csr.toarray()), atol=1e-15)
+
 
 ############################ Addition
 

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -175,6 +175,14 @@ class TestBasicPyInt(BasicMixin, TestCase):
     dtype = int
 
 
+class TestBasicNpInt32(BasicMixin, TestCase):
+    dtype = np.int32
+
+
+class TestBasicNpInt64(BasicMixin, TestCase):
+    dtype = np.int64
+
+
 class TestBasicPyBool(BasicMixin, TestCase):
     dtype = bool
 
@@ -375,6 +383,14 @@ class TestArithmPyInt(ArithmeticsMixin, TestCase):
     dtype = int
 
 
+class TestArithmNpInt32(ArithmeticsMixin, TestCase):
+    dtype = np.int32
+
+
+class TestArithmNpInt64(ArithmeticsMixin, TestCase):
+    dtype = np.int64
+
+
 class TestArithmPyBool(ArithmeticsMixin, TestCase):
     dtype = bool
 
@@ -398,6 +414,14 @@ class TestMulPyInt(MulMixin, TestCase):
     dtype = int
 
 
+class TestMulNpInt32(MulMixin, TestCase):
+    dtype = np.int32
+
+
+class TestMulNpInt64(MulMixin, TestCase):
+    dtype = np.int64
+
+
 class TestMulPyBool(MulMixin, TestCase):
     dtype = bool
 
@@ -419,6 +443,14 @@ class TestSubFloat(SubMixin, TestCase):
 
 class TestSubPyInt(SubMixin, TestCase):
     dtype = int
+
+
+class TestSubNpInt32(SubMixin, TestCase):
+    dtype = np.int32
+
+
+class TestSubNpInt64(SubMixin, TestCase):
+    dtype = np.int64
 
 
 #class TestSubPyBool(SubMixin, TestCase):

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -365,8 +365,31 @@ class ArithmeticsMixin(object):
 
         ma1 = self.iop(ma1, csr)
         assert_(isinstance(ma1, MapArray))
-        assert_allclose(res.todense(),
+        assert_allclose(ma1.todense(),
                         self.op(self.ma.todense(), csr.toarray()), atol=1e-15)
+
+    @skipif(not HAVE_SCIPY)
+    def test_scipy_sparse_sparse_interop(self):
+        # csr_matrix + MapArray should work too
+        ma1 = self.ma.copy()
+        dense = self.rhs.todense()
+        csr = sparse.csr_matrix(dense)
+
+        res = self.op(csr, ma1)
+        assert_(isinstance(res, MapArray))
+        assert_allclose(res.todense(),
+                        self.op(csr.toarray(), ma1.todense()), atol=1e-15)
+
+        # also check the in-place version
+        ma1 = self.ma.copy()
+        dense = self.rhs.todense()
+        csr = sparse.csr_matrix(dense)
+        csr1 = csr.copy()
+
+        csr = self.iop(csr, ma1)
+        assert_(isinstance(csr, MapArray))
+        assert_allclose(csr.todense(),
+                        self.op(csr1.toarray(), self.ma.todense()), atol=1e-15)
 
 
 ############################ Addition

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -695,6 +695,20 @@ class CmpMixin(object):
         assert_equal(self.lhs.todense() > self.rhs,
                      self.lhs.todense() > self.rhs.todense())
 
+    @skipif(not HAVE_SCIPY)
+    def test_greater_coo_lhs(self):
+        data, (row, col) = self.rhs.to_coo()
+        coo = sparse.coo_matrix((data, (row, col)))
+        assert_equal((self.lhs > coo).todense(),
+                      self.lhs.todense() > coo.toarray())
+
+    @skipif(True, 'coo > map fails')
+    def test_greater_coo_lhs(self):
+        data, (row, col) = self.rhs.to_coo()
+        coo = sparse.coo_matrix((data, (row, col)))
+        assert_equal((coo > self.lhs).todense(),
+                      coo.toarray() > self.lhs.todense())
+
 
 class CmpDoubleDouble(CmpMixin, TestCase):
     ldtype = float

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -5,6 +5,10 @@ import numpy as np
 from numpy.testing import (run_module_suite, TestCase, assert_equal, assert_,
                            assert_allclose, assert_raises,)
 from numpy.testing.decorators import knownfailureif, skipif
+try:
+    from numpy.testing import SkipTest
+except ImportError:
+    from nose import SkipTest
 
 from .. import MapArray
 
@@ -368,8 +372,13 @@ class ArithmeticsMixin(object):
         assert_allclose(ma1.todense(),
                         self.op(self.ma.todense(), csr.toarray()), atol=1e-15)
 
+    # multiplication fails :-(
     @skipif(not HAVE_SCIPY)
     def test_scipy_sparse_sparse_interop(self):
+
+        if self.op == operator.mul:
+            raise SkipTest("csr * map fails.")
+
         # csr_matrix + MapArray should work too
         ma1 = self.ma.copy()
         dense = self.rhs.todense()

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -282,8 +282,6 @@ class ArithmeticsMixin(object):
 
         with assert_raises(TypeError):
             self.iop(ma1, [1, 2, 3, 4])
-        with assert_raises(TypeError):
-            self.iop([1, 2, 3, 4], ma1)
 
     def test_sparse_dense_interop(self):
         # dense + sparse densifies for scipy.sparse matrices.


### PR DESCRIPTION
Handle scipy.sparse matrices in binops: check for `tocoo` attribute, and try using it.
This seems to trigger the need for npy_longlong dtype, so add it to the type map.
Also add scipy from wheelhouse to Travis, to be able to test `sparse.csr_matrix`.

- [x] Test reversed operation: csr + map.
- [x] Implement and handle comparisons w/ sparse matrices: csr < map etc.
