### PR TITLE
ENH: default the dtype to the dtype of fill_value

### DIFF
--- a/sparr/sp_map.pyx.in
+++ b/sparr/sp_map.pyx.in
@@ -197,10 +197,20 @@ cdef class MapArray:
 
     __array_priority__ = 10.1     # equal to that of sparse matrices
 
-    def __init__(self, shape=None, fill_value=0, dtype=float):
+    def __init__(self, shape=None, fill_value=None, dtype=None):
         pass
 
-    def __cinit__(self, shape=None, fill_value=0, dtype=float, *args, **kwds):
+    def __cinit__(self, shape=None, fill_value=None, dtype=None, *args, **kwds):
+
+        if dtype is None:
+            if fill_value is None:
+                dtype = np.dtype(float)
+                fill_value = 0.0
+            else:
+                dtype = np.asarray(fill_value).dtype
+        else:
+            if fill_value is None:
+                fill_value = 0
 
         # this seems to convert float etc to numpy dtypes
         dtype = np.dtype(dtype)

--- a/sparr/tests/test_basic.py
+++ b/sparr/tests/test_basic.py
@@ -969,5 +969,22 @@ def check_bad_index_setitem(ma, idx):
         ma[idx] = 42
 
 
+def test_fill_value_dtype():
+    # test that the dtype defaults to the fill_value dtype
+
+    # default is float
+    m = MapArray()
+    assert_equal(m.dtype, np.dtype(float)) 
+
+    # if fill_value is provided, its dtype is used
+    f = np.uint8(1)
+    m = MapArray(fill_value=f)
+    assert_equal(m.dtype, np.dtype(np.uint8))
+
+    # ... unless it's given explicitly
+    m = MapArray(fill_value=4.2, dtype=bool)
+    assert_equal(m.dtype, np.dtype(bool))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
As per suggestion of Stephan Hoyer in scipy-dev ML.